### PR TITLE
Image update - GSP484: Using Cloud Trace on Kubernetes Engine

### DIFF
--- a/terraform/tracing-demo-deployment.yaml
+++ b/terraform/tracing-demo-deployment.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       - name: tracing-demo-container
-        image: gcr.io/pso-examples/tracing-demo:1.0.0
+        image: gcr.io/qwiklabs-resources/tracing-demo:1.0.0
         ports:
         - containerPort: 8080
 ---


### PR DESCRIPTION
- Updated the image path with 'gcr.io/qwiklabs-resources/tracing-demo:1.0.0
- Reference Buganizer: http://b/286787784